### PR TITLE
Resetting state pollution in `Settings`

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -47,3 +47,4 @@ def test_camelcased_response_data_ok():
 
     with override_settings(DJHUG_CAMELCASED_RESPONSE_DATA=True):
         assert Settings().camelcased_response_data
+    del Settings()._Settings__shared_state['camelcased_response_data']

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -23,6 +23,7 @@ def test_register_request_formatters_ok():
 
         assert "application/x-test" in get_request_parsers()
         assert get_request_parsers()["application/x-test"] == request_formatter_test
+    del Settings()._Settings__shared_state['request_parsers_modules']
 
 
 def test_register_response_formatters_ok():
@@ -33,6 +34,7 @@ def test_register_response_formatters_ok():
 
         assert "application/x-test" in get_response_renderers()
         assert get_response_renderers()["application/x-test"] == response_formatter_test
+    del Settings()._Settings__shared_state['response_renderers_modules']
 
 
 def test_response_additional_headers_ok():
@@ -40,6 +42,7 @@ def test_response_additional_headers_ok():
 
     with override_settings(DJHUG_RESPONSE_ADDITIONAL_HEADERS={"Access-Control-Allow-Origin": "*"}):
         assert Settings().response_additional_headers == {"Access-Control-Allow-Origin": "*"}
+    del Settings()._Settings__shared_state['response_additional_headers']
 
 
 def test_camelcased_response_data_ok():


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_camelcased_response_data_ok` by resetting state pollution in `Settings` by deleting attribute `camelcased_response_data` in `Settings()._Settings__shared_state`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_settings.py::test_camelcased_response_data_ok`:

```
    def test_camelcased_response_data_ok():
>       assert not Settings().camelcased_response_data
E       assert not True
E        +  where True = <djhug.settings.Settings object at 0x7fb1a9729640>.camelcased_response_data
E        +    where <djhug.settings.Settings object at 0x7fb1a9729640> = Settings()
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
